### PR TITLE
Double Declaration of "te"

### DIFF
--- a/src/main/java/com/iconmaster/aec/client/gui/GuiAetherReconstructor.java
+++ b/src/main/java/com/iconmaster/aec/client/gui/GuiAetherReconstructor.java
@@ -14,7 +14,6 @@ import org.lwjgl.opengl.GL11;
 public class GuiAetherReconstructor extends AetherCraftGui<TileEntityAetherReconstructor> {
 	private static final ResourceLocation gui_texture = new ResourceLocation(
 			"aec", "textures/gui/aetherReconstructorGui.png");
-	private TileEntityAetherReconstructor te;
 
 	public GuiAetherReconstructor(InventoryPlayer player,
 			TileEntityAetherReconstructor tileEntity) {


### PR DESCRIPTION
The variable "te" is already declared as protected in AetherCraftGui on line 16. This declaration here causes the game to crash with a null pointer when you right click on this block, as the requestSync() function uses the protected "te" over the private one initialized and declared through this class. Removing this line allows the block to function properly.
