### PR TITLE
Fixes for onItemRightClick being called twice

### DIFF
--- a/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
@@ -67,6 +67,7 @@ public class ItemFlyingRing extends Item implements IAetherRing {
 		stack.setItemDamage(1);
 		player.capabilities.allowFlying = true;
 		player.capabilities.isFlying = true;
+		player.fallDistance = 0;
 		
 		player.sendPlayerAbilities();
 		//System.out.println("ACTIVATED");

--- a/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
@@ -48,7 +48,7 @@ public class ItemFlyingRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-		if (!world.isRemote) {
+		if (world.isRemote) {
 			return stack;
 		}
 		

--- a/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemFlyingRing.java
@@ -48,6 +48,10 @@ public class ItemFlyingRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (!world.isRemote) {
+			return stack;
+		}
+		
 		if (stack.getItemDamage() == 0) {
 			if (!canRingFunction(stack,player)) {return stack;}
 			activateRing(stack,player);

--- a/src/main/java/com/iconmaster/aec/item/ItemLightRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemLightRing.java
@@ -62,6 +62,10 @@ public class ItemLightRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (!world.isRemote) {
+			return stack;
+		}
+		
 		if (stack.getItemDamage() == 0) {
 			activateRing(stack,player);
 		} else {

--- a/src/main/java/com/iconmaster/aec/item/ItemLightRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemLightRing.java
@@ -62,7 +62,7 @@ public class ItemLightRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-		if (!world.isRemote) {
+		if (world.isRemote) {
 			return stack;
 		}
 		

--- a/src/main/java/com/iconmaster/aec/item/ItemPhasingRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemPhasingRing.java
@@ -58,6 +58,10 @@ public class ItemPhasingRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (!world.isRemote) {
+			return stack;
+		}
+		
 		if (stack.getItemDamage() == 0) {
 			activateRing(stack,player);
 		} else {

--- a/src/main/java/com/iconmaster/aec/item/ItemPhasingRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemPhasingRing.java
@@ -58,7 +58,7 @@ public class ItemPhasingRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-		if (!world.isRemote) {
+		if (world.isRemote) {
 			return stack;
 		}
 		

--- a/src/main/java/com/iconmaster/aec/item/ItemRegnerationRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemRegnerationRing.java
@@ -56,7 +56,7 @@ public class ItemRegnerationRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-		if (!world.isRemote) {
+		if (world.isRemote) {
 			return stack;
 		}
 		

--- a/src/main/java/com/iconmaster/aec/item/ItemRegnerationRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemRegnerationRing.java
@@ -56,6 +56,10 @@ public class ItemRegnerationRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (!world.isRemote) {
+			return stack;
+		}
+		
 		if (stack.getItemDamage() == 0) {
 			activateRing(stack,player);
 		} else {

--- a/src/main/java/com/iconmaster/aec/item/ItemRepairRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemRepairRing.java
@@ -65,7 +65,7 @@ public class ItemRepairRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
-		if (!world.isRemote) {
+		if (world.isRemote) {
 			return stack;
 		}
 		

--- a/src/main/java/com/iconmaster/aec/item/ItemRepairRing.java
+++ b/src/main/java/com/iconmaster/aec/item/ItemRepairRing.java
@@ -65,6 +65,10 @@ public class ItemRepairRing extends Item implements IAetherRing {
 	
 	@Override
 	public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player) {
+		if (!world.isRemote) {
+			return stack;
+		}
+		
 		if (stack.getItemDamage() == 0) {
 			activateRing(stack,player);
 		} else {


### PR DESCRIPTION
The function onItemRightClick() was being called twice, once from the "server" and once from the "client". These changes fix that issue so that the ring is only activated once, on the client side, before being sent to the server.